### PR TITLE
Ignore eslint v9

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,9 @@ updates:
     directory: '/'
     schedule:
       interval: 'monthly'
+    ignore:
+      - dependency-name: 'eslint'
+        update-types: ['version-update:semver-major']
     groups:
       everything:
         patterns:


### PR DESCRIPTION
This PR temporarily ignores eslint v9 until the ecosystem catches up.